### PR TITLE
modify _config.yml to allow raw HTML images to be built

### DIFF
--- a/src/Undergrad/Calculus/Functions.ipynb
+++ b/src/Undergrad/Calculus/Functions.ipynb
@@ -1039,12 +1039,7 @@
    "metadata": {},
    "source": [
     "2. Given the graph of the function $f$ below.<br>\n",
-    "\n",
-    "    ```{image} Sec2Function2.png\n",
-    "    :alt: function\n",
-    "    :width: 250px\n",
-    "    ```\n",
-    "\n",
+    "    <img src=\"2Function2.png\" width=\"250px\"> <br>\n",
     "    - Find the intervals on which the graph of $f$ is increasing or decreasing\n",
     "    - Find the intervals on which the graph of $f$ is concave up or concave down\n",
     "    - Find the inflection points (if any)"

--- a/src/_config.yml
+++ b/src/_config.yml
@@ -28,3 +28,7 @@ repository:
 html:
   use_issues_button: true
   use_repository_button: true
+
+parse:
+  myst_enable_extensions:
+    - html_image


### PR DESCRIPTION
Modify _config.yml to allow display of raw HTML images. This will allow HTML images to be displayed properly in both local Jupyter Notebook environments and the online textbook. 

Modify HTML image width specification in src/Undergrad/Calculus/Functions.ipynb to enable proper interpretation by MyST for online textbook.

Reference: https://jupyterbook.org/en/stable/content/figures.html#raw-html-images